### PR TITLE
feat: add proxy support (CURLOPT_PROXY)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           echo "erlang ${{ matrix.pair.otp }}" >> .tool-versions
           cp .tool-versions ~/.
           cat .tool-versions
-      - uses: asdf-vm/actions/install@v3
+      - uses: asdf-vm/actions/install@v4
       - name: Install Hex package manager
         run: mix local.hex --force && mix local.rebar --force
       - run: mix deps.get

--- a/devenv.lock
+++ b/devenv.lock
@@ -20,11 +20,10 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
+        "lastModified": 1747046372,
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "treeHash": "2addb7b71a20a25ea74feeaf5c2f6a6b30898ecb",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
         "type": "github"
       },
       "original": {
@@ -33,10 +32,31 @@
         "type": "github"
       }
     },
+    "git-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1750779888,
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
-          "pre-commit-hooks",
+          "git-hooks",
           "nixpkgs"
         ]
       },
@@ -45,7 +65,6 @@
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
         "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "treeHash": "ca14199cabdfe1a06a7b1654c76ed49100a689f9",
         "type": "github"
       },
       "original": {
@@ -70,22 +89,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable": {
-      "locked": {
-        "lastModified": 1722221733,
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "12bf09802d77264e441f48e25459c10c93eada2e",
-        "treeHash": "e959ebf2e25b21ec31266bef769b447e4b907916",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-unstable": {
       "locked": {
         "lastModified": 1722185531,
@@ -102,35 +105,15 @@
         "type": "github"
       }
     },
-    "pre-commit-hooks": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "nixpkgs-stable": "nixpkgs-stable"
-      },
-      "locked": {
-        "lastModified": 1721042469,
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "f451c19376071a90d8c58ab1a953c6e9840527fd",
-        "treeHash": "91f40b7a3b9f6886bd77482cba5b5cd890415a2e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "devenv": "devenv",
+        "git-hooks": "git-hooks",
         "nixpkgs": "nixpkgs",
         "nixpkgs-unstable": "nixpkgs-unstable",
-        "pre-commit-hooks": "pre-commit-hooks"
+        "pre-commit-hooks": [
+          "git-hooks"
+        ]
       }
     }
   },

--- a/devenv.lock
+++ b/devenv.lock
@@ -3,11 +3,11 @@
     "devenv": {
       "locked": {
         "dir": "src/modules",
-        "lastModified": 1722262342,
+        "lastModified": 1773186539,
+        "narHash": "sha256-ObTTa3PTm0JWDh/KIFQ/0rSZtskfwBmkv2uvB+c8R98=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "11a1ca0ad80bc172d2efda34ae542494442dcf48",
-        "treeHash": "c1be883f8fad6adb0369cef0ac6e6c9bd7f3ec66",
+        "rev": "1f48f833600fbbc33b24186ce26598de761ebf26",
         "type": "github"
       },
       "original": {
@@ -17,69 +17,16 @@
         "type": "github"
       }
     },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1747046372,
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "git-hooks": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1750779888,
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
+      "inputs": {
+        "nixpkgs-src": "nixpkgs-src"
+      },
       "locked": {
-        "lastModified": 1716977621,
+        "lastModified": 1772749504,
+        "narHash": "sha256-eqtQIz0alxkQPym+Zh/33gdDjkkch9o6eHnMPnXFXN0=",
         "owner": "cachix",
         "repo": "devenv-nixpkgs",
-        "rev": "4267e705586473d3e5c8d50299e71503f16a6fb6",
-        "treeHash": "6d9f1f7ca0faf1bc2eeb397c78a49623260d3412",
+        "rev": "08543693199362c1fddb8f52126030d0d374ba2e",
         "type": "github"
       },
       "original": {
@@ -89,13 +36,30 @@
         "type": "github"
       }
     },
-    "nixpkgs-unstable": {
+    "nixpkgs-src": {
+      "flake": false,
       "locked": {
-        "lastModified": 1722185531,
+        "lastModified": 1772173633,
+        "narHash": "sha256-MOH58F4AIbCkh6qlQcwMycyk5SWvsqnS/TCfnqDlpj4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "52ec9ac3b12395ad677e8b62106f0b98c1f8569d",
-        "treeHash": "561285c3e9ff92b7fff8f6111828711f012cb158",
+        "rev": "c0f3d81a7ddbc2b1332be0d8481a672b4f6004d6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1772963539,
+        "narHash": "sha256-9jVDGZnvCckTGdYT53d/EfznygLskyLQXYwJLKMPsZs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9dcb002ca1690658be4a04645215baea8b95f31d",
         "type": "github"
       },
       "original": {
@@ -108,12 +72,8 @@
     "root": {
       "inputs": {
         "devenv": "devenv",
-        "git-hooks": "git-hooks",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-unstable": "nixpkgs-unstable",
-        "pre-commit-hooks": [
-          "git-hooks"
-        ]
+        "nixpkgs-unstable": "nixpkgs-unstable"
       }
     }
   },

--- a/lib/ex_curl.ex
+++ b/lib/ex_curl.ex
@@ -13,6 +13,7 @@ defmodule ExCurl do
     * `:verbose` - if curl should output verbose logs to stdout, useful for debugging. Defaults to `false`
     * `:http_auth_negotiate` - if curl should use HTTP Negotiation (SPNEGO) as defined in [RFC 4559](https://datatracker.ietf.org/doc/html/rfc4559).
       Note: this flag requires curl to be compiled with a suitable GSS-API or SSPI library. Defaults to `false`
+    * `:proxy` - proxy to use for transfers. Can be hostname or IP address with optional port number. Supports various proxy types (http, https, socks4, socks5). Defaults to `nil`
 
   ## Error messages
 

--- a/lib/request.ex
+++ b/lib/request.ex
@@ -21,6 +21,7 @@ defmodule ExCurl.Request do
       return_metrics: bool,
       verbose: bool,
       http_auth_negotiate: bool,
+      proxy: ?[]u8,
   };
 
   pub const RequestConfiguration = struct {
@@ -215,6 +216,14 @@ defmodule ExCurl.Request do
       defer allocator.free(url_as_c_string);
       if (cURL.curl_easy_setopt(handle, cURL.CURLOPT_URL, url_as_c_string.ptr) != cURL.CURLE_OK)
           unreachable;
+
+      // Proxy
+      if (config.flags.proxy) |proxy| {
+          const proxy_as_c_string = allocator.dupeZ(u8, proxy) catch unreachable;
+          defer allocator.free(proxy_as_c_string);
+          if (cURL.curl_easy_setopt(handle, cURL.CURLOPT_PROXY, proxy_as_c_string.ptr) != cURL.CURLE_OK)
+              unreachable;
+      }
   }
 
   fn readFn(dest: [*c]u8, size: usize, nmemb: usize, config: *RequestConfiguration) callconv(.C) usize {

--- a/lib/request_configuration.ex
+++ b/lib/request_configuration.ex
@@ -16,7 +16,8 @@ defmodule ExCurl.RequestConfiguration do
         ssl_verifypeer: Keyword.get(opts, :ssl_verifypeer, true),
         return_metrics: Keyword.get(opts, :return_metrics, false),
         verbose: Keyword.get(opts, :verbose, false),
-        http_auth_negotiate: Keyword.get(opts, :http_auth_negotiate, false)
+        http_auth_negotiate: Keyword.get(opts, :http_auth_negotiate, false),
+        proxy: Keyword.get(opts, :proxy, nil)
       }
     }
   end

--- a/lib/request_configuration.ex
+++ b/lib/request_configuration.ex
@@ -1,7 +1,6 @@
 defmodule ExCurl.RequestConfiguration do
   @moduledoc false
 
-  @derive {Jason.Encoder, only: [:headers, :url, :method, :body, :flags]}
   defstruct headers: %{}, url: "", method: "", body: "", flags: %{}
 
   def build(method, url, opts \\ []) do

--- a/mix.exs
+++ b/mix.exs
@@ -29,6 +29,7 @@ defmodule ExCurl.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
+      {:jason, "~> 1.4"},
       {:ex_doc, "~> 0.34", only: :dev, runtime: false},
       {:bypass, "~> 2.0", only: :test},
       {:zigler, "~> 0.13", runtime: false}

--- a/test/ex_curl_test.exs
+++ b/test/ex_curl_test.exs
@@ -173,4 +173,19 @@ defmodule ExCurlTest do
       ExCurl.TestClient.request!("GET", "https://")
     end
   end
+
+  test "can use proxy option" do
+    proxy = System.get_env("TEST_PROXY")
+
+    if proxy do
+      {:ok, %ExCurl.Response{} = resp} =
+        ExCurl.TestClient.get("https://httpbin.org/ip", proxy: proxy)
+
+      assert resp.status_code == 200
+      assert String.contains?(resp.body, "origin")
+    else
+      # Skip test if no proxy is configured
+      :ok
+    end
+  end
 end

--- a/test/ex_curl_test.exs
+++ b/test/ex_curl_test.exs
@@ -117,8 +117,9 @@ defmodule ExCurlTest do
   end
 
   test "error on expired SSL cert" do
-    assert {:error, "PEER_FAILED_VERIFICATION"} ==
-             ExCurl.TestClient.get("https://expired.badssl.com")
+    valid_errors = ["PEER_FAILED_VERIFICATION", "SSL_CONNECT_ERROR"]
+    assert {:error, error_msg} = ExCurl.TestClient.get("https://expired.badssl.com")
+    assert error_msg in valid_errors
   end
 
   test "can disable ssl peer validation" do

--- a/test/ex_curl_test.exs
+++ b/test/ex_curl_test.exs
@@ -173,19 +173,4 @@ defmodule ExCurlTest do
       ExCurl.TestClient.request!("GET", "https://")
     end
   end
-
-  test "can use proxy option" do
-    proxy = System.get_env("TEST_PROXY")
-
-    if proxy do
-      {:ok, %ExCurl.Response{} = resp} =
-        ExCurl.TestClient.get("https://httpbin.org/ip", proxy: proxy)
-
-      assert resp.status_code == 200
-      assert String.contains?(resp.body, "origin")
-    else
-      # Skip test if no proxy is configured
-      :ok
-    end
-  end
 end

--- a/test/proxy_test.exs
+++ b/test/proxy_test.exs
@@ -1,0 +1,23 @@
+defmodule ExCurl.ProxyTest do
+  use ExUnit.Case, async: true
+
+  test "can use proxy option" do
+    bypass = Bypass.open()
+    proxy_url = "localhost:#{bypass.port}"
+
+    Bypass.expect_once(bypass, "GET", "/get", fn conn ->
+      assert conn.host == "httpbin.org"
+      Plug.Conn.send_resp(conn, 200, "OK from proxy")
+    end)
+
+    {:ok, resp} = ExCurl.TestClient.get("http://httpbin.org/get", proxy: proxy_url)
+
+    assert resp.status_code == 200
+    assert resp.body == "OK from proxy"
+  end
+
+  test "fails when proxy is not running or reachable" do
+    assert {:error, "COULDNT_RESOLVE_PROXY"} =
+             ExCurl.TestClient.get("https://httpbin.org/get", proxy: "invalidhost")
+  end
+end

--- a/test/proxy_test.exs
+++ b/test/proxy_test.exs
@@ -18,6 +18,6 @@ defmodule ExCurl.ProxyTest do
 
   test "fails when proxy is not running or reachable" do
     assert {:error, "COULDNT_RESOLVE_PROXY"} =
-             ExCurl.TestClient.get("https://httpbin.org/get", proxy: "invalidhost")
+             ExCurl.TestClient.get("https://httpbin.org/get", proxy: "nonexistent-host")
   end
 end


### PR DESCRIPTION
Builds on top of #15 :

Adds a `:proxy` request option that maps to libcurl's `CURLOPT_PROXY`, supporting hostname/IP with optional port and various proxy types (http, https, socks4, socks5)