### PR TITLE
fix: set CURLOPT_POSTFIELDSIZE to prevent empty body POST hang

### DIFF
--- a/lib/request.ex
+++ b/lib/request.ex
@@ -204,6 +204,8 @@ defmodule ExCurl.Request do
       if (std.mem.eql(u8, config.method, "POST")) {
           if (cURL.curl_easy_setopt(handle, cURL.CURLOPT_POST, @as(c_long, 1)) != cURL.CURLE_OK)
               unreachable;
+          if (cURL.curl_easy_setopt(handle, cURL.CURLOPT_POSTFIELDSIZE, @as(c_long, @intCast(config.body.len))) != cURL.CURLE_OK)
+              unreachable;
       } else if (!std.mem.eql(u8, config.method, "GET")) {
           const method_as_c_string = allocator.dupeZ(u8, config.method) catch unreachable;
           defer allocator.free(method_as_c_string);

--- a/test/body_test.exs
+++ b/test/body_test.exs
@@ -21,6 +21,21 @@ defmodule ExCurl.BodyTest do
     assert resp.body == "OK"
   end
 
+  test "sends content-length 0 for POST requests without a body", %{bypass: bypass} do
+    Bypass.expect(bypass, "POST", "/test", fn conn ->
+      case Plug.Conn.get_req_header(conn, "content-length") do
+        ["0"] -> Plug.Conn.send_resp(conn, 200, "OK")
+        _ -> Plug.Conn.send_resp(conn, 400, "Unexpected content-length")
+      end
+    end)
+
+    {:ok, %ExCurl.Response{} = resp} =
+      ExCurl.TestClient.post("http://localhost:#{bypass.port}/test")
+
+    assert resp.status_code == 200
+    assert resp.body == "OK"
+  end
+
   test "does not send request body for GET requests", %{bypass: bypass} do
     Bypass.expect(bypass, "GET", "/test", fn conn ->
       case Plug.Conn.read_body(conn) do


### PR DESCRIPTION
The empty body was causing tests to hang in some cases.