### PR TITLE
refactor: use dirty_io and set curl options via comptime table

### DIFF
--- a/lib/ex_curl.ex
+++ b/lib/ex_curl.ex
@@ -216,10 +216,7 @@ defmodule ExCurl do
     end
   end
 
-  defp do_request(%RequestConfiguration{} = config, opts) do
-    case Keyword.get(opts, :dirty_cpu, false) do
-      true -> Request.request_dirty_cpu(config)
-      _ -> Request.request(config)
-    end
+  defp do_request(%RequestConfiguration{} = config, _opts) do
+    Request.request(config)
   end
 end

--- a/lib/request.ex
+++ b/lib/request.ex
@@ -3,7 +3,7 @@ defmodule ExCurl.Request do
   use Zig,
     otp_app: :ex_curl,
     c: [link_lib: {:system, "curl"}],
-    nifs: [request: [], request_dirty_cpu: [:dirty_cpu]]
+    nifs: [request: [:dirty_io]]
 
   ~Z"""
   const beam = @import("beam");
@@ -47,10 +47,6 @@ defmodule ExCurl.Request do
       headers: []u8,
       metrics: ?ResponseMetrics,
   };
-
-  pub fn request_dirty_cpu(config: RequestConfiguration) !beam.term {
-      return request(config);
-  }
 
   pub fn request(config: RequestConfiguration) !beam.term {
       // initialize curl and vars

--- a/lib/request.ex
+++ b/lib/request.ex
@@ -160,30 +160,17 @@ defmodule ExCurl.Request do
       };
   }
 
+  const bool_flag_opts = .{
+      .{ "verbose", cURL.CURLOPT_VERBOSE },
+      .{ "follow_location", cURL.CURLOPT_FOLLOWLOCATION },
+      .{ "ssl_verifypeer", cURL.CURLOPT_SSL_VERIFYPEER },
+      .{ "ssl_verifyhost", cURL.CURLOPT_SSL_VERIFYHOST },
+  };
+
   fn setCurlOpts(allocator: std.mem.Allocator, handle: *cURL.CURL, config: RequestConfiguration) !void {
-      if (config.flags.verbose) {
-          if (cURL.curl_easy_setopt(handle, cURL.CURLOPT_VERBOSE, @as(c_long, 1)) != cURL.CURLE_OK)
-              unreachable;
-      }
-
-      if (config.flags.follow_location) {
-          if (cURL.curl_easy_setopt(handle, cURL.CURLOPT_FOLLOWLOCATION, @as(c_long, 1)) != cURL.CURLE_OK)
-              unreachable;
-      }
-
-      if (config.flags.ssl_verifypeer) {
-          if (cURL.curl_easy_setopt(handle, cURL.CURLOPT_SSL_VERIFYPEER, @as(c_long, 1)) != cURL.CURLE_OK)
-              unreachable;
-      } else {
-          if (cURL.curl_easy_setopt(handle, cURL.CURLOPT_SSL_VERIFYPEER, @as(c_long, 0)) != cURL.CURLE_OK)
-              unreachable;
-      }
-
-      if (config.flags.ssl_verifyhost) {
-          if (cURL.curl_easy_setopt(handle, cURL.CURLOPT_SSL_VERIFYHOST, @as(c_long, 1)) != cURL.CURLE_OK)
-              unreachable;
-      } else {
-          if (cURL.curl_easy_setopt(handle, cURL.CURLOPT_SSL_VERIFYHOST, @as(c_long, 0)) != cURL.CURLE_OK)
+      inline for (bool_flag_opts) |flag| {
+          const value: c_long = if (@field(config.flags, flag[0])) 1 else 0;
+          if (cURL.curl_easy_setopt(handle, flag[1], value) != cURL.CURLE_OK)
               unreachable;
       }
 
@@ -203,25 +190,21 @@ defmodule ExCurl.Request do
           if (cURL.curl_easy_setopt(handle, cURL.CURLOPT_POSTFIELDSIZE, @as(c_long, @intCast(config.body.len))) != cURL.CURLE_OK)
               unreachable;
       } else if (!std.mem.eql(u8, config.method, "GET")) {
-          const method_as_c_string = allocator.dupeZ(u8, config.method) catch unreachable;
-          defer allocator.free(method_as_c_string);
-          if (cURL.curl_easy_setopt(handle, cURL.CURLOPT_CUSTOMREQUEST, method_as_c_string.ptr) != cURL.CURLE_OK)
-              unreachable;
+          setStringOpt(allocator, handle, cURL.CURLOPT_CUSTOMREQUEST, config.method);
       }
 
-      // URL
-      const url_as_c_string = allocator.dupeZ(u8, config.url) catch unreachable;
-      defer allocator.free(url_as_c_string);
-      if (cURL.curl_easy_setopt(handle, cURL.CURLOPT_URL, url_as_c_string.ptr) != cURL.CURLE_OK)
-          unreachable;
+      setStringOpt(allocator, handle, cURL.CURLOPT_URL, config.url);
 
-      // Proxy
       if (config.flags.proxy) |proxy| {
-          const proxy_as_c_string = allocator.dupeZ(u8, proxy) catch unreachable;
-          defer allocator.free(proxy_as_c_string);
-          if (cURL.curl_easy_setopt(handle, cURL.CURLOPT_PROXY, proxy_as_c_string.ptr) != cURL.CURLE_OK)
-              unreachable;
+          setStringOpt(allocator, handle, cURL.CURLOPT_PROXY, proxy);
       }
+  }
+
+  fn setStringOpt(allocator: std.mem.Allocator, handle: *cURL.CURL, opt: cURL.CURLoption, value: []const u8) void {
+      const c_string = allocator.dupeZ(u8, value) catch unreachable;
+      defer allocator.free(c_string);
+      if (cURL.curl_easy_setopt(handle, opt, c_string.ptr) != cURL.CURLE_OK)
+          unreachable;
   }
 
   fn readFn(dest: [*c]u8, size: usize, nmemb: usize, config: *RequestConfiguration) callconv(.c) usize {

--- a/test/client_test.exs
+++ b/test/client_test.exs
@@ -15,7 +15,7 @@ defmodule ExCurl.ClientTest do
     end)
 
     defmodule HeaderClient do
-      use ExCurl.Client, defaults: [headers: %{"test-header" => "true"}, dirty_cpu: true]
+      use ExCurl.Client, defaults: [headers: %{"test-header" => "true"}]
     end
 
     {:ok, %ExCurl.Response{} = resp} = HeaderClient.get("http://localhost:#{bypass.port}/test")
@@ -30,7 +30,7 @@ defmodule ExCurl.ClientTest do
 
     defmodule BaseURLClient do
       @port bypass.port
-      use ExCurl.Client, defaults: [base_url: "http://localhost:#{@port}", dirty_cpu: true]
+      use ExCurl.Client, defaults: [base_url: "http://localhost:#{@port}"]
     end
 
     {:ok, %ExCurl.Response{} = resp} = BaseURLClient.get("/test")
@@ -49,7 +49,7 @@ defmodule ExCurl.ClientTest do
     defmodule FunctionDefaultsClient do
       use ExCurl.Client, defaults: &get_defaults/0
 
-      defp get_defaults, do: [dirty_cpu: true, headers: %{"test-header" => "true"}]
+      defp get_defaults, do: [headers: %{"test-header" => "true"}]
     end
 
     {:ok, %ExCurl.Response{} = resp} =
@@ -70,7 +70,7 @@ defmodule ExCurl.ClientTest do
     defmodule AtomFunctionDefaultsClient do
       use ExCurl.Client, defaults: :get_defaults
 
-      def get_defaults, do: [dirty_cpu: true, headers: %{"test-header" => "true"}]
+      def get_defaults, do: [headers: %{"test-header" => "true"}]
     end
 
     {:ok, %ExCurl.Response{} = resp} =
@@ -86,7 +86,7 @@ defmodule ExCurl.ClientTest do
     end)
 
     defmodule HandleResponseClient do
-      use ExCurl.Client, defaults: [dirty_cpu: true]
+      use ExCurl.Client
 
       def handle_response(%ExCurl.Response{status_code: 200, body: "OK"}), do: "HANDLED"
     end

--- a/test/support/test_client.ex
+++ b/test/support/test_client.ex
@@ -1,8 +1,4 @@
 defmodule ExCurl.TestClient do
-  @moduledoc """
-  There is a race condition when listening for connections
-  and making requests to localhost simulataneously. Setting `dirty_cpu` to `true`
-  will remove the race condition.
-  """
-  use ExCurl.Client, defaults: [dirty_cpu: true]
+  @moduledoc false
+  use ExCurl.Client
 end


### PR DESCRIPTION
- **Breaking change:** `dirty_cpu` has been removed as an option. It should be removed/dropped if you were previously passing it in; the request will still work but `dirty_cpu` will be ignored.
  - Requests are IO bound so `dirty_io` is the right approach. The previous use of the regular scheduler (blocking) and `dirty_cpu`  was incorrect.
- curl options are now set via a comptime table for boolean flags and a `setStringOpt` helper for string options. Slightly cleaner implementation.